### PR TITLE
Fixed excessive tasks spawning during session connection loss

### DIFF
--- a/Tests/Technosoftware/UaClient.Tests/SubscriptionUnitTests.cs
+++ b/Tests/Technosoftware/UaClient.Tests/SubscriptionUnitTests.cs
@@ -27,6 +27,22 @@ namespace Technosoftware.UaClient.Tests
     [Parallelizable]
     public class SubscriptionUnitTests
     {
+        private const PublishStateChangedMask kSessionNotConnected = PublishStateChangedMask.Stopped | PublishStateChangedMask.SessionNotConnected;
+
+        public record KeepAliveTestDataProvider(PublishStateChangedMask ExpectedPublishState) : IFormattable
+        {
+            public bool SessionConnected { get; init; }
+            public bool SessionReconnecting { get; init; }
+            public bool SessionKeepAliveStopped { get; init; }
+            public string ToString(string format, IFormatProvider formatProvider)
+            {
+                return $"Connected={SessionConnected}, " +
+                    $"reconnecting={SessionReconnecting}, " +
+                    $"keepAlive={SessionKeepAliveStopped}. " +
+                    $"Expected status:{ExpectedPublishState}";
+            }
+        }
+
         private sealed class SubscriptionContainer : IDisposable
         {
             private readonly CancellationTokenRegistration m_tokedCancellation;
@@ -58,28 +74,31 @@ namespace Technosoftware.UaClient.Tests
             return Task.Delay(Subscription.RepublishMessageTimeout + 100, ct);
         }
 
-        private static IUaSession BuildSessionMock(Func<uint, uint, bool> republishHandler)
+        private static IUaSession BuildSessionMock(Func<uint, uint, bool> republishHandler = null, Action<Mock<IUaSession>> setup = null)
         {
             uint subscriptionIdSeed = 0u;
 
             var session = new Mock<IUaSession>();
-            session
-                .Setup(x => x.RepublishAsync(It.IsAny<uint>(), It.IsAny<uint>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync<uint, uint, CancellationToken, IUaSession, (bool, ServiceResult)>((
-                    subscriptionId,
-                    sequenceNumber,
-                    ct) =>
-                {
-                    if (subscriptionId > subscriptionIdSeed)
+            if (republishHandler is not null)
+            {
+                session
+                    .Setup(x => x.RepublishAsync(It.IsAny<uint>(), It.IsAny<uint>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync<uint, uint, CancellationToken, IUaSession, (bool, ServiceResult)>((
+                        subscriptionId,
+                        sequenceNumber,
+                        ct) =>
                     {
-                        return (true, StatusCodes.BadSubscriptionIdInvalid);
-                    }
-                    if (republishHandler(subscriptionId, sequenceNumber))
-                    {
-                        return (true, ServiceResult.Good);
-                    }
-                    return (true, StatusCodes.BadMessageNotAvailable);
-                });
+                        if (subscriptionId > subscriptionIdSeed)
+                        {
+                            return (true, StatusCodes.BadSubscriptionIdInvalid);
+                        }
+                        if (republishHandler(subscriptionId, sequenceNumber))
+                        {
+                            return (true, ServiceResult.Good);
+                        }
+                        return (true, StatusCodes.BadMessageNotAvailable);
+                    });
+            }
             session
                 .Setup(x => x
                     .CreateSubscriptionAsync(
@@ -129,6 +148,7 @@ namespace Technosoftware.UaClient.Tests
                         Results = [.. subscriptionIds.Select(id => id > subscriptionIdSeed ? StatusCodes.BadSubscriptionIdInvalid : StatusCodes.Good)],
                         DiagnosticInfos = [.. subscriptionIds.Select(_ => new DiagnosticInfo())]
                     });
+            setup?.Invoke(session);
             return session.Object;
         }
 
@@ -334,6 +354,49 @@ namespace Technosoftware.UaClient.Tests
             {
                 Assert.That(subscription.Notifications, Is.EquivalentTo(messages.Skip(1)));
             }
+        }
+
+        [DatapointSource]
+        public IEnumerable<KeepAliveTestDataProvider> SubscriptionKeepAliveValues()
+        {
+            yield return new(PublishStateChangedMask.Stopped) { SessionConnected = true, SessionReconnecting = false, SessionKeepAliveStopped = false };
+
+            yield return new(kSessionNotConnected) { SessionConnected = false, SessionReconnecting = false, SessionKeepAliveStopped = false };
+            yield return new(kSessionNotConnected) { SessionConnected = false, SessionReconnecting = true, SessionKeepAliveStopped = false };
+            yield return new(kSessionNotConnected) { SessionConnected = false, SessionReconnecting = false, SessionKeepAliveStopped = true };
+            yield return new(kSessionNotConnected) { SessionConnected = false, SessionReconnecting = true, SessionKeepAliveStopped = true };
+
+            yield return new(kSessionNotConnected) { SessionConnected = true, SessionReconnecting = true, SessionKeepAliveStopped = false };
+            yield return new(kSessionNotConnected) { SessionConnected = true, SessionReconnecting = true, SessionKeepAliveStopped = true };
+
+            yield return new(kSessionNotConnected) { SessionConnected = true, SessionReconnecting = false, SessionKeepAliveStopped = true };
+        }
+
+        [Theory]
+        [CancelAfter(Subscription.MinKeepAliveTimerInterval * 10)]
+        public async Task RespectsStateOfSessionDuringKeepAliveCalls(KeepAliveTestDataProvider testData, CancellationToken ct)
+        {
+            var keepAliveCompleted = new TaskCompletionSource<PublishStateChangedMask>(TaskCreationOptions.RunContinuationsAsynchronously);
+            void KeepAliveHasTriggered(Subscription x, PublishStateChangedEventArgs y) => keepAliveCompleted.TrySetResult(y.Status);
+            IUaSession session = BuildSessionMock(
+                setup: mock =>
+                {
+                    mock.Setup(x => x.Connected).Returns(testData.SessionConnected);
+                    mock.Setup(x => x.Reconnecting).Returns(testData.SessionReconnecting);
+                    mock.Setup(x => x.KeepAliveStopped).Returns(testData.SessionKeepAliveStopped);
+                });
+
+            using var subscription = new Subscription(
+                NUnitTelemetryContext.Create(),
+                new() { PublishingEnabled = true })
+            {
+                Session = session
+            };
+            subscription.PublishStatusChanged += KeepAliveHasTriggered;
+            await subscription.CreateAsync(ct).ConfigureAwait(false);
+            await Task.WhenAny(keepAliveCompleted.Task, Task.Delay(-1, ct)).ConfigureAwait(false);
+
+            Assert.That(keepAliveCompleted.Task.Result, Is.EqualTo(testData.ExpectedPublishState));
         }
     }
 }

--- a/src/Technosoftware/UaClient/Session/Session.cs
+++ b/src/Technosoftware/UaClient/Session/Session.cs
@@ -3337,6 +3337,12 @@ namespace Technosoftware.UaClient
                 return false;
             }
 
+            if (KeepAliveStopped)
+            {
+                m_logger.LogWarning("Publish skipped due to session lost connection. Last successfull keepalive: {LastKeepAlive}", LastKeepAliveTime);
+                return false;
+            }
+
             // get event handler to modify ack list
             EventHandler<PublishSequenceNumbersToAcknowledgeEventArgs>? callback
                 = m_PublishSequenceNumbersToAcknowledge;

--- a/src/Technosoftware/UaClient/Subscription/Subscription.cs
+++ b/src/Technosoftware/UaClient/Subscription/Subscription.cs
@@ -31,7 +31,6 @@ namespace Technosoftware.UaClient
     /// </summary>
     public class Subscription : ISnapshotRestore<SubscriptionState>, IDisposable, ICloneable
     {
-        private const int kMinKeepAliveTimerInterval = 1000;
         private const int kKeepAliveTimerMargin = 1000;
         private const int kRepublishMessageExpiredTimeout = 10000;
 
@@ -39,6 +38,11 @@ namespace Technosoftware.UaClient
         /// Duration to wait before republishing missed notification
         /// </summary>
         public const int RepublishMessageTimeout = 2500;
+
+        /// <summary>
+        /// Minimum keep alive interval
+        /// </summary>
+        public const int MinKeepAliveTimerInterval = 1000;
 
         /// <summary>
         /// Creates a empty object.
@@ -2103,7 +2107,9 @@ namespace Technosoftware.UaClient
 
             if (session != null &&
                 session.Connected &&
-                !session.Reconnecting)
+                !session.Reconnecting &&
+                !session.KeepAliveStopped
+                )
             {
                 TraceState("PUBLISHING STOPPED");
 
@@ -2197,7 +2203,7 @@ namespace Technosoftware.UaClient
         {
             return Math.Max(
                 Math.Min(m_keepAliveInterval * 3, int.MaxValue),
-                kMinKeepAliveTimerInterval);
+                MinKeepAliveTimerInterval);
         }
 
         /// <summary>
@@ -2311,12 +2317,12 @@ namespace Technosoftware.UaClient
         {
             int keepAliveInterval = (int)
                 Math.Min(CurrentPublishingInterval * (CurrentKeepAliveCount + 1), int.MaxValue);
-            if (keepAliveInterval < kMinKeepAliveTimerInterval)
+            if (keepAliveInterval < MinKeepAliveTimerInterval)
             {
                 keepAliveInterval = (int)Math.Min(
                     PublishingInterval * (KeepAliveCount + 1),
                     int.MaxValue);
-                keepAliveInterval = Math.Max(kMinKeepAliveTimerInterval, keepAliveInterval);
+                keepAliveInterval = Math.Max(MinKeepAliveTimerInterval, keepAliveInterval);
             }
             return keepAliveInterval;
         }


### PR DESCRIPTION
## Conditions Required to Reproduce

Connect sessions to the server (5 sessions with default configuration with 10 subscriptions should be enough to reproduce the problem).
Terminate opc server.
The number of tasks will start to grow (this can be observed using dotnet-counters).
For 30 sessions with 40 subscriptions each, the task count increases from 1,000 to 50,000 per second.
After the connection is restored, the app state returns to normal.

## Root Cause

* ```Subscription.OnKeepAlive``` attempts to send publish requests even when there is no connection to the server. Technically, this is handled in ```Subscription.HandleOnKeepAliveStopped```, but the current conditions do not account for a lost connection.
* During publishing, the session spawns new tasks each time (via ```Task.Run in Session.OnPublishComplete``` and ```Task<PublishResponse> task = PublishAsync() in Session.BeginPublish```). If the connection is lost, a large number of tasks are started simultaneously (they fail fast without a connection). I did not observe any thread locks, so it appears to be simply a high volume of tasks.

## Proposed changes

* ```Subscription.HandleOnKeepAliveStopped``` should check whether the session has lost connection. ```Session.KeepAliveStopped``` looks suitable for this.
* The same connection check was added to ```Session.BeginPublish()```.

## Related Issues

- Fixes #10

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Enhancement (non-breaking change which adds functionality)
- [x] Test enhancement (non-breaking change to increase test coverage)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected, requires version increase of Nuget packages)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/technosoftware-gmbh/UaSolutions/blob/master/CONTRIBUTING.md) documentation.
- [x] I have signed the [CLA](https://cla-assistant.io/technosoftware-gmbh/UaSolutions).
- [x] I ran tests locally with my changes, all passed.
- [x] I have added tests that prove my fix is effective or that my feature works and increased code coverage.
- [ ] I have added necessary documentation (if appropriate).
- [ ] Any dependent changes have been merged and published in downstream modules.

## Further comments

See OPC Foundation [#3707](https://github.com/OPCFoundation/UA-.NETStandard/pull/3707)